### PR TITLE
Updated module to build on 3.2.0 kernel.

### DIFF
--- a/README
+++ b/README
@@ -23,7 +23,7 @@ pts:
 
 module:
 
- The module is tested in kernel 2.6.26-2 (debian) and kernel 2.6.30
+ The module is tested in kernel 3.2.0
 
   When loaded, create 8 ttys interconnected:
   /dev/tnt0  <=>  /dev/tnt1 

--- a/module/tty0tty.c
+++ b/module/tty0tty.c
@@ -368,7 +368,7 @@ static void tty0tty_set_termios(struct tty_struct *tty, struct ktermios *old_ter
 }
 
 
-static int tty0tty_tiocmget(struct tty_struct *tty, struct file *file)
+static int tty0tty_tiocmget(struct tty_struct *tty)
 {
 	struct tty0tty_serial *tty0tty = tty->driver_data;
 
@@ -390,7 +390,7 @@ static int tty0tty_tiocmget(struct tty_struct *tty, struct file *file)
 	return result;
 }
 
-static int tty0tty_tiocmset(struct tty_struct *tty, struct file *file,
+static int tty0tty_tiocmset(struct tty_struct *tty,
 				unsigned int set, unsigned int clear)
 {
 	struct tty0tty_serial *tty0tty = tty->driver_data;
@@ -440,7 +440,7 @@ static int tty0tty_tiocmset(struct tty_struct *tty, struct file *file,
 }
 
 
-static int tty0tty_ioctl_tiocgserial(struct tty_struct *tty, struct file *file,
+static int tty0tty_ioctl_tiocgserial(struct tty_struct *tty,
 					unsigned int cmd, unsigned long arg)
 {
 	struct tty0tty_serial *tty0tty = tty->driver_data;
@@ -476,7 +476,7 @@ static int tty0tty_ioctl_tiocgserial(struct tty_struct *tty, struct file *file,
 	return -ENOIOCTLCMD;
 }
 
-static int tty0tty_ioctl_tiocmiwait(struct tty_struct *tty, struct file *file,
+static int tty0tty_ioctl_tiocmiwait(struct tty_struct *tty,
 					unsigned int cmd, unsigned long arg)
 {
 	struct tty0tty_serial *tty0tty = tty->driver_data;
@@ -517,7 +517,7 @@ static int tty0tty_ioctl_tiocmiwait(struct tty_struct *tty, struct file *file,
 	return -ENOIOCTLCMD;
 }
 
-static int tty0tty_ioctl_tiocgicount(struct tty_struct *tty, struct file *file,
+static int tty0tty_ioctl_tiocgicount(struct tty_struct *tty,
 					unsigned int cmd, unsigned long arg)
 {
 	struct tty0tty_serial *tty0tty = tty->driver_data;
@@ -548,7 +548,7 @@ static int tty0tty_ioctl_tiocgicount(struct tty_struct *tty, struct file *file,
 	return -ENOIOCTLCMD;
 }
 
-static int tty0tty_ioctl(struct tty_struct *tty, struct file *file,
+static int tty0tty_ioctl(struct tty_struct *tty,
 				unsigned int cmd, unsigned long arg)
 {
 #ifdef SCULL_DEBUG
@@ -556,11 +556,11 @@ static int tty0tty_ioctl(struct tty_struct *tty, struct file *file,
 #endif
 	switch (cmd) {
 	case TIOCGSERIAL:
-		return tty0tty_ioctl_tiocgserial(tty, file, cmd, arg);
+		return tty0tty_ioctl_tiocgserial(tty, cmd, arg);
 	case TIOCMIWAIT:
-		return tty0tty_ioctl_tiocmiwait(tty, file, cmd, arg);
+		return tty0tty_ioctl_tiocmiwait(tty, cmd, arg);
 	case TIOCGICOUNT:
-		return tty0tty_ioctl_tiocgicount(tty, file, cmd, arg);
+		return tty0tty_ioctl_tiocgicount(tty, cmd, arg);
 	}
 
 	return -ENOIOCTLCMD;


### PR DESCRIPTION
Hi,

Thanks for making this available!  I tried using the tty0tty module from sourceforge recently to simulate a device that I communicated with by use of a serial library.  The library performed tcgetattr and tcsetattr commands which were not supported by the sourceforge version, but the copy in this repository does.  I had to make the (trivial) changes to get the module to build on the 3.2.0 kernel (Unbuntu 12.04 LTS base), so I thought I'd offer them back if you're interested.

I understand if you want to keep your module where it's at due to the kernel version you're using.  Perhaps the 3.2.0 version could be a branch or something...

Anyway, thanks again for making this available.  It was quite helpful!

carpie
