### PR TITLE
Add support for Linux > 4.11

### DIFF
--- a/module/tty0tty.c
+++ b/module/tty0tty.c
@@ -39,6 +39,9 @@
 #include <linux/serial.h>
 #include <linux/sched.h>
 #include <linux/version.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+#include <linux/sched/signal.h>
+#endif
 #include <asm/uaccess.h>
 
 


### PR DESCRIPTION
Based on: http://dpdk.org/dev/patchwork/patch/22036/

I needed this to allow compilation on an updated Fedora 25. I can confirm that the module works without problems after that.