### PR TITLE
Minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 *.mod.c
 *.o.cmd
 *.ko.cmd
+*.mod.cmd
+*.mod
 /module/Module.symvers
 /module/modules.order
 /module/.tmp_versions
@@ -23,3 +25,16 @@ pts/tty0tty
 .settings
 .pydevproject
 
+# debian packaging artifacts
+debian/*
+debhelper/*
+files
+*-dkms.debhelper.log
+*-dkms.dkms.debhelper
+*-dkms.postinst.debhelper
+*-dkms.prerm.debhelper
+*-dkms.substvars
+*-dkms/*
+
+# vim temporary file
+*.swp

--- a/module/tty0tty.c
+++ b/module/tty0tty.c
@@ -214,7 +214,7 @@ static int tty0tty_write(struct tty_struct *tty, const unsigned char *buffer,
 			 int count)
 {
 	struct tty0tty_serial *tty0tty = tty->driver_data;
-	int retval = -EINVAL;
+	int retval = 0;
 	struct tty_struct *ttyx = NULL;
 
 	if (!tty0tty)
@@ -261,7 +261,7 @@ exit:
 static int tty0tty_write_room(struct tty_struct *tty)
 {
 	struct tty0tty_serial *tty0tty = tty->driver_data;
-	int room = -EINVAL;
+	int room = 0;
 
 	if (!tty0tty)
 		return -ENODEV;


### PR DESCRIPTION
1. Adjustments to .gitignore: kernel module & debian package build artifacts
2. Return 0 instead of -EINVAL on write when there are no readers to block writer instead of failing it