### PR TITLE
Return 0 space instead of -EINVAL when there are no readers

### DIFF
--- a/module/tty0tty.c
+++ b/module/tty0tty.c
@@ -214,7 +214,7 @@ static int tty0tty_write(struct tty_struct *tty, const unsigned char *buffer,
 			 int count)
 {
 	struct tty0tty_serial *tty0tty = tty->driver_data;
-	int retval = -EINVAL;
+	int retval = 0;
 	struct tty_struct *ttyx = NULL;
 
 	if (!tty0tty)
@@ -261,7 +261,7 @@ exit:
 static int tty0tty_write_room(struct tty_struct *tty)
 {
 	struct tty0tty_serial *tty0tty = tty->driver_data;
-	int room = -EINVAL;
+	int room = 0;
 
 	if (!tty0tty)
 		return -ENODEV;


### PR DESCRIPTION
Actually no errors are suppressed here. Returning 0 is more correct in this case because -EINVAL would mean there is some invalid value passed on write, which is not true - write request itself is totally fine; returning 0 means no data was successfully written, which is true because there is no reader to consume.

NOTE: this is a split of #26