### PR TITLE
Ignore debian packaging and modern kernel build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 *.mod.c
 *.o.cmd
 *.ko.cmd
+*.mod.cmd
+*.mod
 /module/Module.symvers
 /module/modules.order
 /module/.tmp_versions
@@ -23,3 +25,16 @@ pts/tty0tty
 .settings
 .pydevproject
 
+# debian packaging artifacts
+debian/*
+debhelper/*
+files
+*-dkms.debhelper.log
+*-dkms.dkms.debhelper
+*-dkms.postinst.debhelper
+*-dkms.prerm.debhelper
+*-dkms.substvars
+*-dkms/*
+
+# vim temporary file
+*.swp


### PR DESCRIPTION
Adjustments to .gitignore: kernel module & debian package build artifacts
Tested on kernel 5.4 / ubuntu 20.04

NOTE: this is a split of #26