### PR TITLE
Allow tty0tty_write_room() to return ENOBUFS

### DIFF
--- a/module/tty0tty.c
+++ b/module/tty0tty.c
@@ -261,7 +261,7 @@ exit:
 static int tty0tty_write_room(struct tty_struct *tty)
 {
 	struct tty0tty_serial *tty0tty = tty->driver_data;
-	int room = -EINVAL;
+	int room = -ENOBUFS;
 
 	if (!tty0tty)
 		return -ENODEV;


### PR DESCRIPTION
The very generic error code EINVAL, in function tty0tty_write,
replaced with more informative "No buffer space available"
return code ENOBUFS.

Signed-off-by: Geert Stappers <stappers@stappers.it>