### PR TITLE
Less generic error code for write()

### DIFF
--- a/module/tty0tty.c
+++ b/module/tty0tty.c
@@ -214,7 +214,7 @@ static int tty0tty_write(struct tty_struct *tty, const unsigned char *buffer,
 			 int count)
 {
 	struct tty0tty_serial *tty0tty = tty->driver_data;
-	int retval = -EINVAL;
+	int retval = -ENOTCONN;
 	struct tty_struct *ttyx = NULL;
 
 	if (!tty0tty)


### PR DESCRIPTION
Replaced the very generic EINVAL error code with ENOTCONN.
Because it is easy to trigger the error state of endpoint not connected.

Signed-off-by: Geert Stappers <stappers@stappers.it>