### PR TITLE
tty0tty: port `tty.h` calls to `5.14+`

### DIFF
--- a/module/tty0tty.c
+++ b/module/tty0tty.c
@@ -258,7 +258,7 @@ exit:
 	return retval;
 }
 
-static int tty0tty_write_room(struct tty_struct *tty)
+static unsigned int tty0tty_write_room(struct tty_struct *tty)
 {
 	struct tty0tty_serial *tty0tty = tty->driver_data;
 	int room = -EINVAL;
@@ -628,7 +628,7 @@ static int __init tty0tty_init(void)
 	printk(KERN_DEBUG "%s - \n", __FUNCTION__);
 #endif
 	/* allocate the tty driver */
-	tty0tty_tty_driver = alloc_tty_driver(2 * pairs);
+	tty0tty_tty_driver = tty_alloc_driver(2 * pairs, 0);
 	if (!tty0tty_tty_driver)
 		return -ENOMEM;
 
@@ -664,7 +664,7 @@ static int __init tty0tty_init(void)
 	retval = tty_register_driver(tty0tty_tty_driver);
 	if (retval) {
 		printk(KERN_ERR "failed to register tty0tty tty driver");
-		put_tty_driver(tty0tty_tty_driver);
+		tty_driver_kref_put(tty0tty_tty_driver);
 		return retval;
 	}
 


### PR DESCRIPTION
See: https://github.com/torvalds/linux/commit/9f90a4ddef4e4d3aa4229f6b117d4e57231457b3
Closes: #36
Closes: #35
Signed-off-by: Matthew Bakhtiari <dev@mtbk.me>