### PR TITLE
Bug fix for some kernel version for function: tty0tty_write_room

### DIFF
--- a/module/tty0tty.c
+++ b/module/tty0tty.c
@@ -258,7 +258,11 @@ exit:
 	return retval;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
 static unsigned int tty0tty_write_room(struct tty_struct *tty)
+#else
+static int tty0tty_write_room(struct tty_struct *tty)
+#endif
 {
 	struct tty0tty_serial *tty0tty = tty->driver_data;
 	int room = -ENOBUFS;


### PR DESCRIPTION
I have added a macro that checks the kernel version of client for build and compile module , because is some kernels int return value is valid and in some other unsigned int , so what i have done is just a check version for making module 
Thanks