### PR TITLE
Fix type incompatibility on kernel >=6.6.1

### DIFF
--- a/module/tty0tty.c
+++ b/module/tty0tty.c
@@ -210,8 +210,13 @@ static void tty0tty_close(struct tty_struct *tty, struct file *file)
 		do_close(tty0tty);
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,6,1)
+static ssize_t tty0tty_write(struct tty_struct *tty, const unsigned char *buffer,
+			 size_t count)
+#else
 static int tty0tty_write(struct tty_struct *tty, const unsigned char *buffer,
 			 int count)
+#endif
 {
 	struct tty0tty_serial *tty0tty = tty->driver_data;
 	int retval = 0;


### PR DESCRIPTION
A [recent kernel patch](https://lore.kernel.org/all/20230810091510.13006-30-jirislaby@kernel.org/) changed the types of counts and retvals in `tty_operations.write` to `size_t` and `ssize_t`, respectively.  This PR updates the code to use the correct types on kernel 6.6.1 and later.