### PR TITLE
Wait after writing so userland gets expected speed

### DIFF
--- a/module/tty0tty.c
+++ b/module/tty0tty.c
@@ -306,6 +306,8 @@ static void tty0tty_set_termios(struct tty_struct *tty,
 	unsigned int cflag;
 	unsigned int iflag;
 	unsigned int bits_per_byte;
+	unsigned int baud_rate;
+	u64 nanosecs_per_byte;
 
 	DEBUG_PRINTK(KERN_DEBUG "%s - \n", __FUNCTION__);
 
@@ -404,7 +406,12 @@ static void tty0tty_set_termios(struct tty_struct *tty,
 	}
 
 	/* get the baud rate wanted */
-	DEBUG_PRINTK(KERN_DEBUG " - baud rate = %d\n", tty_get_baud_rate(tty));
+	baud_rate = tty_get_baud_rate(tty);
+	DEBUG_PRINTK(KERN_DEBUG " - baud rate = %d\n", baud_rate);
+
+	/* get the time a real serial port would require to push a byte */
+	nanosecs_per_byte = 1000000000ULL / (baud_rate / bits_per_byte);
+	DEBUG_PRINTK(KERN_DEBUG " - time per byte = %lluns\n", nanosecs_per_byte);
 }
 
 //static int tty0tty_tiocmget(struct tty_struct *tty, struct file *file)

--- a/module/tty0tty.c
+++ b/module/tty0tty.c
@@ -46,6 +46,12 @@
 #define DRIVER_AUTHOR "Luis Claudio Gamboa Lopes <lcgamboa@yahoo.com>"
 #define DRIVER_DESC "tty0tty null modem driver"
 
+#ifdef SCULL_DEBUG
+#define DEBUG_PRINTK(...) do { printk(__VA_ARGS__); } while (0)
+#else
+#define DEBUG_PRINTK(...)
+#endif
+
 /* Module information */
 MODULE_AUTHOR(DRIVER_AUTHOR);
 MODULE_DESCRIPTION(DRIVER_DESC);
@@ -102,9 +108,8 @@ static int tty0tty_open(struct tty_struct *tty, struct file *file)
 	int msr = 0;
 	int mcr = 0;
 
-#ifdef SCULL_DEBUG
-	printk(KERN_DEBUG "%s - \n", __FUNCTION__);
-#endif
+	DEBUG_PRINTK(KERN_DEBUG "%s - \n", __FUNCTION__);
+
 	/* initialize the pointer in case something fails */
 	tty->driver_data = NULL;
 
@@ -169,9 +174,8 @@ static void do_close(struct tty0tty_serial *tty0tty)
 {
 	unsigned int msr = 0;
 
-#ifdef SCULL_DEBUG
-	printk(KERN_DEBUG "%s - \n", __FUNCTION__);
-#endif
+	DEBUG_PRINTK(KERN_DEBUG "%s - \n", __FUNCTION__);
+
 	if ((tty0tty->tty->index % 2) == 0) {
 		if (tty0tty_table[tty0tty->tty->index + 1] != NULL)
 			if (tty0tty_table[tty0tty->tty->index + 1]->open_count >
@@ -203,9 +207,8 @@ static void tty0tty_close(struct tty_struct *tty, struct file *file)
 {
 	struct tty0tty_serial *tty0tty = tty->driver_data;
 
-#ifdef SCULL_DEBUG
-	printk(KERN_DEBUG "%s - \n", __FUNCTION__);
-#endif
+	DEBUG_PRINTK(KERN_DEBUG "%s - \n", __FUNCTION__);
+
 	if (tty0tty)
 		do_close(tty0tty);
 }
@@ -303,9 +306,7 @@ static void tty0tty_set_termios(struct tty_struct *tty,
 	unsigned int cflag;
 	unsigned int iflag;
 
-#ifdef SCULL_DEBUG
-	printk(KERN_DEBUG "%s - \n", __FUNCTION__);
-#endif
+	DEBUG_PRINTK(KERN_DEBUG "%s - \n", __FUNCTION__);
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,7,0)
 	cflag = tty->termios.c_cflag;
@@ -320,78 +321,77 @@ static void tty0tty_set_termios(struct tty_struct *tty,
 		if ((cflag == old_termios->c_cflag) &&
 		    (RELEVANT_IFLAG(iflag) ==
 		     RELEVANT_IFLAG(old_termios->c_iflag))) {
-#ifdef SCULL_DEBUG
-			printk(KERN_DEBUG " - nothing to change...\n");
-#endif
+			DEBUG_PRINTK(KERN_DEBUG " - nothing to change...\n");
 			return;
 		}
 	}
-#ifdef SCULL_DEBUG
+
 	/* get the byte size */
 	switch (cflag & CSIZE) {
 	case CS5:
-		printk(KERN_DEBUG " - data bits = 5\n");
+		DEBUG_PRINTK(KERN_DEBUG " - data bits = 5\n");
 		break;
 	case CS6:
-		printk(KERN_DEBUG " - data bits = 6\n");
+		DEBUG_PRINTK(KERN_DEBUG " - data bits = 6\n");
 		break;
 	case CS7:
-		printk(KERN_DEBUG " - data bits = 7\n");
+		DEBUG_PRINTK(KERN_DEBUG " - data bits = 7\n");
 		break;
 	default:
 	case CS8:
-		printk(KERN_DEBUG " - data bits = 8\n");
+		DEBUG_PRINTK(KERN_DEBUG " - data bits = 8\n");
 		break;
 	}
 
 	/* determine the parity */
 	if (cflag & PARENB)
 		if (cflag & PARODD)
-			printk(KERN_DEBUG " - parity = odd\n");
+			DEBUG_PRINTK(KERN_DEBUG " - parity = odd\n");
 		else
-			printk(KERN_DEBUG " - parity = even\n");
+			DEBUG_PRINTK(KERN_DEBUG " - parity = even\n");
 	else
-		printk(KERN_DEBUG " - parity = none\n");
+		DEBUG_PRINTK(KERN_DEBUG " - parity = none\n");
 
 	/* figure out the stop bits requested */
 	if (cflag & CSTOPB)
-		printk(KERN_DEBUG " - stop bits = 2\n");
+		DEBUG_PRINTK(KERN_DEBUG " - stop bits = 2\n");
 	else
-		printk(KERN_DEBUG " - stop bits = 1\n");
+		DEBUG_PRINTK(KERN_DEBUG " - stop bits = 1\n");
 
 	/* figure out the hardware flow control settings */
 	if (cflag & CRTSCTS)
-		printk(KERN_DEBUG " - RTS/CTS is enabled\n");
+		DEBUG_PRINTK(KERN_DEBUG " - RTS/CTS is enabled\n");
 	else
-		printk(KERN_DEBUG " - RTS/CTS is disabled\n");
+		DEBUG_PRINTK(KERN_DEBUG " - RTS/CTS is disabled\n");
 
 	/* determine software flow control */
 	/* if we are implementing XON/XOFF, set the start and 
 	 * stop character in the device */
 	if (I_IXOFF(tty) || I_IXON(tty)) {
+#ifdef SCULL_DEBUG
 		unsigned char stop_char = STOP_CHAR(tty);
 		unsigned char start_char = START_CHAR(tty);
+#endif
 
 		/* if we are implementing INBOUND XON/XOFF */
 		if (I_IXOFF(tty))
-			printk(KERN_DEBUG " - INBOUND XON/XOFF is enabled, "
+			DEBUG_PRINTK(KERN_DEBUG " - INBOUND XON/XOFF is enabled, "
 			       "XON = %2x, XOFF = %2x\n", start_char,
 			       stop_char);
 		else
-			printk(KERN_DEBUG " - INBOUND XON/XOFF is disabled\n");
+			DEBUG_PRINTK(KERN_DEBUG " - INBOUND XON/XOFF is disabled\n");
 
 		/* if we are implementing OUTBOUND XON/XOFF */
 		if (I_IXON(tty))
-			printk(KERN_DEBUG " - OUTBOUND XON/XOFF is enabled, "
+			DEBUG_PRINTK(KERN_DEBUG " - OUTBOUND XON/XOFF is enabled, "
 			       "XON = %2x, XOFF = %2x\n", start_char,
 			       stop_char);
 		else
-			printk(KERN_DEBUG " - OUTBOUND XON/XOFF is disabled\n");
+			DEBUG_PRINTK(KERN_DEBUG " - OUTBOUND XON/XOFF is disabled\n");
 	}
 
 	/* get the baud rate wanted */
-	printk(KERN_DEBUG " - baud rate = %d\n", tty_get_baud_rate(tty));
-#endif
+	DEBUG_PRINTK(KERN_DEBUG " - baud rate = %d\n", tty_get_baud_rate(tty));
 }
 
 //static int tty0tty_tiocmget(struct tty_struct *tty, struct file *file)
@@ -422,9 +422,7 @@ static int tty0tty_tiocmset(struct tty_struct *tty,
 	unsigned int mcr = tty0tty->mcr;
 	unsigned int msr = 0;
 
-#ifdef SCULL_DEBUG
-	printk(KERN_DEBUG "%s - \n", __FUNCTION__);
-#endif
+	DEBUG_PRINTK(KERN_DEBUG "%s - \n", __FUNCTION__);
 
 	if ((tty0tty->tty->index % 2) == 0) {
 		if (tty0tty_table[tty0tty->tty->index + 1] != NULL)
@@ -488,9 +486,8 @@ static int tty0tty_ioctl_tiocgserial(struct tty_struct *tty,
 {
 	struct tty0tty_serial *tty0tty = tty->driver_data;
 
-#ifdef SCULL_DEBUG
-	printk(KERN_DEBUG "%s - \n", __FUNCTION__);
-#endif
+	DEBUG_PRINTK(KERN_DEBUG "%s - \n", __FUNCTION__);
+
 	if (cmd == TIOCGSERIAL) {
 		struct serial_struct tmp;
 
@@ -525,9 +522,8 @@ static int tty0tty_ioctl_tiocmiwait(struct tty_struct *tty,
 {
 	struct tty0tty_serial *tty0tty = tty->driver_data;
 
-#ifdef SCULL_DEBUG
-	printk(KERN_DEBUG "%s - \n", __FUNCTION__);
-#endif
+	DEBUG_PRINTK(KERN_DEBUG "%s - \n", __FUNCTION__);
+
 	if (cmd == TIOCMIWAIT) {
 		DECLARE_WAITQUEUE(wait, current);
 		struct async_icount cnow;
@@ -566,9 +562,8 @@ static int tty0tty_ioctl_tiocgicount(struct tty_struct *tty,
 {
 	struct tty0tty_serial *tty0tty = tty->driver_data;
 
-#ifdef SCULL_DEBUG
-	printk(KERN_DEBUG "%s - \n", __FUNCTION__);
-#endif
+	DEBUG_PRINTK(KERN_DEBUG "%s - \n", __FUNCTION__);
+
 	if (cmd == TIOCGICOUNT) {
 		struct async_icount cnow = tty0tty->icount;
 		struct serial_icounter_struct icount;
@@ -595,9 +590,8 @@ static int tty0tty_ioctl_tiocgicount(struct tty_struct *tty,
 static int tty0tty_ioctl(struct tty_struct *tty,
 			 unsigned int cmd, unsigned long arg)
 {
-#ifdef SCULL_DEBUG
-	printk(KERN_DEBUG "%s - %04X \n", __FUNCTION__, cmd);
-#endif
+	DEBUG_PRINTK(KERN_DEBUG "%s - %04X \n", __FUNCTION__, cmd);
+
 	switch (cmd) {
 	case TIOCGSERIAL:
 		return tty0tty_ioctl_tiocgserial(tty, cmd, arg);
@@ -638,9 +632,9 @@ static int __init tty0tty_init(void)
 	for (i = 0; i < 2 * pairs; i++) {
 		tty0tty_table[i] = NULL;
 	}
-#ifdef SCULL_DEBUG
-	printk(KERN_DEBUG "%s - \n", __FUNCTION__);
-#endif
+
+	DEBUG_PRINTK(KERN_DEBUG "%s - \n", __FUNCTION__);
+
 	/* allocate the tty driver */
 	tty0tty_tty_driver = tty_alloc_driver(2 * pairs, 0);
 	if (!tty0tty_tty_driver)
@@ -691,9 +685,8 @@ static void __exit tty0tty_exit(void)
 	struct tty0tty_serial *tty0tty;
 	int i;
 
-#ifdef SCULL_DEBUG
-	printk(KERN_DEBUG "%s - \n", __FUNCTION__);
-#endif
+	DEBUG_PRINTK(KERN_DEBUG "%s - \n", __FUNCTION__);
+
 	for (i = 0; i < 2 * pairs; ++i) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,7,0)
 		tty_port_destroy(&tport[i]);

--- a/module/tty0tty.c
+++ b/module/tty0tty.c
@@ -305,6 +305,7 @@ static void tty0tty_set_termios(struct tty_struct *tty,
 {
 	unsigned int cflag;
 	unsigned int iflag;
+	unsigned int bits_per_byte;
 
 	DEBUG_PRINTK(KERN_DEBUG "%s - \n", __FUNCTION__);
 
@@ -329,34 +330,46 @@ static void tty0tty_set_termios(struct tty_struct *tty,
 	/* get the byte size */
 	switch (cflag & CSIZE) {
 	case CS5:
-		DEBUG_PRINTK(KERN_DEBUG " - data bits = 5\n");
+		bits_per_byte = 5;
 		break;
 	case CS6:
-		DEBUG_PRINTK(KERN_DEBUG " - data bits = 6\n");
+		bits_per_byte = 6;
 		break;
 	case CS7:
-		DEBUG_PRINTK(KERN_DEBUG " - data bits = 7\n");
+		bits_per_byte = 7;
 		break;
 	default:
 	case CS8:
-		DEBUG_PRINTK(KERN_DEBUG " - data bits = 8\n");
+		bits_per_byte = 8;
 		break;
 	}
 
+	DEBUG_PRINTK(KERN_DEBUG " - data bits = %d\n", bits_per_byte);
+
+	/* Add start bit */
+	bits_per_byte++;
+
 	/* determine the parity */
-	if (cflag & PARENB)
+	if (cflag & PARENB) {
 		if (cflag & PARODD)
 			DEBUG_PRINTK(KERN_DEBUG " - parity = odd\n");
 		else
 			DEBUG_PRINTK(KERN_DEBUG " - parity = even\n");
-	else
+		/* Add parity bit */
+		bits_per_byte++;
+	} else
 		DEBUG_PRINTK(KERN_DEBUG " - parity = none\n");
 
 	/* figure out the stop bits requested */
-	if (cflag & CSTOPB)
+	if (cflag & CSTOPB) {
 		DEBUG_PRINTK(KERN_DEBUG " - stop bits = 2\n");
-	else
+		bits_per_byte+=2;
+	} else {
 		DEBUG_PRINTK(KERN_DEBUG " - stop bits = 1\n");
+		bits_per_byte+=1;
+	}
+
+	DEBUG_PRINTK(KERN_DEBUG " - bits per byte = %d\n", bits_per_byte);
 
 	/* figure out the hardware flow control settings */
 	if (cflag & CRTSCTS)


### PR DESCRIPTION
Constrain tty0tty's bandwidth by waiting the required amount of time after writing bytes, so that userland can expect write/read speeds consistent with the current baud rate, data bits, parity and stop bits settings.
