### PR TITLE
Include udev rules in Debian package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -7,6 +7,7 @@ VERSION=$(shell dpkg-parsechangelog |grep ^Version:|cut -d ' ' -f 2)
 
 override_dh_install:
 	dh_install module/Makefile module/tty0tty.c usr/src/tty0tty-$(VERSION)/
+	dh_install module/50-tty0tty.rules etc/udev/rules.d/
 
 override_dh_dkms:
 	dh_dkms -V $(VERSION)


### PR DESCRIPTION
Udev rules were already present in the repository, but not packaged in the .deb package.

Fixes #9