### PR TITLE
Fix build error with message: invalid initializer on 4.10.0 version kernel.

### DIFF
--- a/module/tty0tty.c
+++ b/module/tty0tty.c
@@ -228,7 +228,11 @@ static int tty0tty_write(struct tty_struct *tty, const unsigned char *buffer,
 	int retval = 0;
 	struct tty_struct *ttyx = NULL;
 	u64 elapsed, delay;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)
 	ktime_t start_time = ktime_get_ns();
+#else
+	u64 start_time = ktime_get_ns();
+#endif
 
 	if (!tty0tty)
 		return -ENODEV;


### PR DESCRIPTION
Add kernel version compare based on https://github.com/torvalds/linux/commit/2456e855354415bfaeb7badaa14e11b3e02c8466