### PR TITLE
Include termios.h instead of termio.h

### DIFF
--- a/pts/tty0tty.c
+++ b/pts/tty0tty.c
@@ -35,7 +35,7 @@
 #ifdef __APPLE__
 #include <term.h>
 #else
-#include <termio.h>
+#include <termios.h>
 #endif
 
 static char buffer[1024];


### PR DESCRIPTION
termio.h was removed from glibc in version 2.42 (released in July 2025)